### PR TITLE
Download original result instead of smoothed version

### DIFF
--- a/wombo/styles.py
+++ b/wombo/styles.py
@@ -92,4 +92,8 @@ STYLES = {
     'dreamwave v2': 97,
     'illustrated v2': 98,
     'abstract fluid v2': 99,
+    'ink v2': 100,
+    'poster art': 101,
+    'figure v2': 102,
+    'horror v2': 103
 }


### PR DESCRIPTION
Wombo Dream applies a harmful upscaler at the final step of the process that results in loss of detail. This commit checks for an upscaled version and, if it finds one, downloads the original instead. This commit also fixes a typo that caused input images to fail, and brings the styles list up to date with 4 new styles.